### PR TITLE
[fix] encode URI for sharing

### DIFF
--- a/scripts/share.js
+++ b/scripts/share.js
@@ -1,5 +1,5 @@
 $('#share').click(function () {
-    navigator.clipboard.writeText(`${window.location.href}?s=${localStorage.getItem("NextPauseChoice").replace(" ", "%20")}`);
+    navigator.clipboard.writeText(`${window.location.href}?s=${encodeURI(localStorage.getItem("NextPauseChoice"))}`);
     $('h6').show();
     setTimeout(() => {
         $('h6').hide();


### PR DESCRIPTION
When sharing a URL for a choice with 2 spaces (e.g. "Gymnase de Nyon"), only the first space was replaced (use `.replace()` instead of `.replaceAll()`). Either ways the better way to do it is to use the [encodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) function, as in this commit.